### PR TITLE
Quick Fix: Find the closest panorama in a 2km radius from coordinates

### DIFF
--- a/load.js
+++ b/load.js
@@ -1,16 +1,43 @@
+var maxTries = 3;
 
-  var panorama;
-  function initialize() {
-    picked = all[Math.floor(Math.random()*all.length)]
-    // debugger
-    panorama = new google.maps.StreetViewPanorama(
+function initialize() {
+  var picked = all[Math.floor(Math.random()*all.length)];
+  var streetViewService = new google.maps.StreetViewService();
+
+  streetViewService.getPanorama(
+    {
+      location: new google.maps.LatLng(picked[0], picked[1]),
+    // It will return the nearest panorama when the
+    // given radius is 2000 meters or less.
+    // This way, it should always return something 🏄
+      radius: 2000
+    }, function(data, status) {
+      if (status === 'OK') {
+        var panorama = new google.maps.StreetViewPanorama(
         document.getElementById('street-view'),
         {
-          // position: {lat: one.lat, lng: one.lng},
-          position: {lat: picked[0], lng: picked[1]},
-          // position: {lat: 21.46225, lng: -158.00366},
+          position: data.location.latLng,
           pov: {heading: 165, pitch: 0},
-          // status: "OK"
           zoom: 1
         });
-  }
+      } else {
+          // Try up to three times with random coordinates
+          // If not, redirecting the browser to what it needs: tacos
+          if (maxTries-- > 0) {
+            initialize();
+          } else {
+            getTacos();
+          }
+      }
+  });
+}
+
+function getTacos() {
+  var losHermanosId = 'B7aVSGDC5YzTrbhy9MzXyA';
+  var panorama = new google.maps.StreetViewPanorama(
+    document.getElementById('street-view'),
+    {
+      pano: losHermanosId,
+      zoom: 1
+    });
+}


### PR DESCRIPTION
By looking at the [API](https://developers.google.com/maps/documentation/javascript/streetview) I noticed that there is an option called `radius` in `getPanorama`. 

This option returns the closest Panorama within a radius from the given position (the lat/long randomly picked). Meaning that if we're trying to draw a Panorama for a point which doesn't have one available, like an ocean or just a location not on a road, it'll find something in the large area.

I voluntarily set it to 2km to make sure to always find something. In places like Antarctica it seems hard to find points within even 500 meters from the coordinates currently stored.

If for some obscure reasons It can't find anything 3 times in a row, redirecting the browser to a taco place in Bushwick.